### PR TITLE
fix: packages updates & windows compatibility

### DIFF
--- a/DihedralCalculator.py
+++ b/DihedralCalculator.py
@@ -21,13 +21,14 @@
 
 # Removes warning messages from Biopython. Comment out to debug
 import warnings
+
 warnings.filterwarnings("ignore")
 
-import Bio.PDB
-import pandas as pd
-import numpy as np
 import math
 
+import Bio.PDB
+import numpy as np
+import pandas as pd
 
 
 def ResidueNames(chain):
@@ -232,13 +233,13 @@ def ModelDihedrals(model, model_num, iter_chains=True, chain_id=None):
 
 		for chain in model:
 			chain_summaryDF = ChainSummary(chain)
-			model_summaryDF = model_summaryDF.append(chain_summaryDF, ignore_index=True)
+			model_summaryDF = pd.concat([model_summaryDF, chain_summaryDF], ignore_index=True)
 
 	# If multiple chains are present, default: calculate dihedrals from all chains
 	else:
 		chain = model[chain_id]
 		chain_summaryDF = ChainSummary(chain)
-		model_summaryDF = model_summaryDF.append(chain_summaryDF, ignore_index=True)
+		model_summaryDF = pd.concat([model_summaryDF, chain_summaryDF], ignore_index=True)
 
 	# Append model number information to final DataFrame
 	model_ID_list = [model_num] * len(model_summaryDF)
@@ -275,7 +276,7 @@ def ExtractDihedrals(pdb_file_name=None, iter_models=True, model_number=0,
 				for model in models:
 
 					model_dihedrals = ModelDihedrals(model, model_number, iter_chains, chain_id)
-					pdb_summaryDF = pdb_summaryDF.append(model_dihedrals, ignore_index=True)
+					pdb_summaryDF = pd.concat([pdb_summaryDF, model_dihedrals], ignore_index=True)
 
 					model_number += 1
 
@@ -284,7 +285,7 @@ def ExtractDihedrals(pdb_file_name=None, iter_models=True, model_number=0,
 				try:
 					model = Bio.PDB.PDBParser().get_structure(pdb_code, pdb_file_name)[model_number]
 					model_dihedrals = ModelDihedrals(model, model_number)
-					pdb_summaryDF = pdb_summaryDF.append(model_dihedrals, ignore_index=True)
+					pdb_summaryDF = pd.concat([pdb_summaryDF, model_dihedrals], ignore_index=True)
 				# Invalid model number given 
 				except:
 					inv_model = True

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ The dependence previous versions of Ramachandran-Plotter had on Phenix has been 
 
 ## Bug fixes:
 
+### 07/10/2023
+
+Crash fixes:
+ - Dataframe.append(...) is deprecated since pandas 2.0, replaced by pandas.concat(...)
+ - Matplotlib style *seaborn-poster* was renamed *seaborn-v0_8-poster* since 3.6.3 version
+
+Bug fixes:
+ - Temporary png image was not deleted on Windows, replace *os.command()* by *os.remove()*
+
 ### 27/03/2022
 
 - Improved readability:

--- a/RamachandranPlotter.py
+++ b/RamachandranPlotter.py
@@ -25,15 +25,17 @@
 	====================================================================================
 """
 
+import os
+
+import matplotlib.pyplot as plt
 # Base functions
 import pandas as pd
-import matplotlib.pyplot as plt
-import os
 
 # Package functions
 from DihedralCalculator import *
 from PlotterFunctions import *
 from RamaArgumentParser import *
+
 
 # Main function
 def main(pdb, itmod, model_num, itchain, chain_num, plot_type, out_dir, verb, save, file_type):
@@ -150,8 +152,7 @@ def main(pdb, itmod, model_num, itchain, chain_num, plot_type, out_dir, verb, sa
 		# ... as PDF
 		plt.savefig(str(plot_name[:-4] + '.' + file_type), bbox_inches=0, pad_inches=None)
 	
-	rm_command = str("rm " + plot_name + ".png")
-	os.system(rm_command)
+	os.remove(str(plot_name + '.png'))
 
 	plt.close()
 

--- a/RamachandranPlotter.py
+++ b/RamachandranPlotter.py
@@ -119,7 +119,7 @@ def main(pdb, itmod, model_num, itchain, chain_num, plot_type, out_dir, verb, sa
 	# Plotting user's PDB dihedral angles
 	VerboseStatement(verb, "Plotting Ramachandran diagram")
 
-	plt.style.use("seaborn-poster")
+	plt.style.use("seaborn-v0_8-poster")
 
 	fig, ax = plt.subplots(1,1, figsize=figure_size, tight_layout=True)		# Defining plot area. 
 


### PR DESCRIPTION
Hello, I made some fixes to be compatible with the newest versions of Matplotlib and pandas. (not tested on linux)

Crash fixes:
 - Dataframe.append(...) is deprecated since pandas 2.0, replaced by pandas.concat(...)
 - Matplotlib style *seaborn-poster* was renamed *seaborn-v0_8-poster* since 3.6.3 version

Bug fixes:
 - Temporary png image was not deleted on Windows, replace *os.command()* by *os.remove()*